### PR TITLE
fix: headers are immutable error

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -57,7 +57,7 @@ export function serve(userRoutes: Routes): void {
   });
 }
 
-async function newResponse(
+function newResponse(
   res: Response,
   headers: Record<string, string>,
 ): Promise<Response> {
@@ -100,7 +100,7 @@ async function handleRequest(
         }
       }
     } else {
-      response = await newResponse(response, {
+      response = newResponse(response, {
         "x-function-cache-hit": "true",
       });
     }
@@ -190,7 +190,7 @@ export function serveStatic(
 
       const cType = contentType(String(lookup(filePath)));
       if (cType) {
-        response = await newResponse(response, { "content-type": cType });
+        response = newResponse(response, { "content-type": cType });
       }
 
       if (typeof intervene === "function") {
@@ -208,7 +208,7 @@ export function serveStatic(
         response = (await globalCache.match(request)) as Response;
       }
     } else {
-      response = await newResponse(response, {
+      response = newResponse(response, {
         "x-function-cache-hit": "true",
       });
     }

--- a/mod.ts
+++ b/mod.ts
@@ -57,6 +57,17 @@ export function serve(userRoutes: Routes): void {
   });
 }
 
+async function newResponse(res: Response, headers: Record<string, string>): Promise<Response> {
+    return new Response(await res.blob(), {
+        headers: {
+            ...Object.fromEntries(res.headers.entries()),
+            ...headers,
+        },
+        status: res.status,
+        statusText: res.statusText,
+    });
+}
+
 async function handleRequest(
   request: Request,
   routes: Routes,
@@ -86,7 +97,7 @@ async function handleRequest(
         }
       }
     } else {
-      response.headers.set("x-function-cache-hit", "true");
+      response = await newResponse(response, { "x-function-cache-hit": "true" });
     }
 
     // return not found page if no handler is found.
@@ -173,7 +184,7 @@ export function serveStatic(
       }
 
       const cType = contentType(String(lookup(filePath)));
-      if (cType) response.headers.set("content-type", cType);
+      if (cType) response = await newResponse(response, { "content-type": cType });
 
       if (typeof intervene === "function") {
         response = await intervene(request, response);
@@ -190,7 +201,7 @@ export function serveStatic(
         response = (await globalCache.match(request)) as Response;
       }
     } else {
-      response.headers.set("x-function-cache-hit", "true");
+      response = await newResponse(response, { "x-function-cache-hit": "true" });
     }
 
     return response;

--- a/mod.ts
+++ b/mod.ts
@@ -57,15 +57,18 @@ export function serve(userRoutes: Routes): void {
   });
 }
 
-async function newResponse(res: Response, headers: Record<string, string>): Promise<Response> {
-    return new Response(res.body, {
-        headers: {
-            ...Object.fromEntries(res.headers.entries()),
-            ...headers,
-        },
-        status: res.status,
-        statusText: res.statusText,
-    });
+async function newResponse(
+  res: Response,
+  headers: Record<string, string>,
+): Promise<Response> {
+  return new Response(res.body, {
+    headers: {
+      ...Object.fromEntries(res.headers.entries()),
+      ...headers,
+    },
+    status: res.status,
+    statusText: res.statusText,
+  });
 }
 
 async function handleRequest(
@@ -97,7 +100,9 @@ async function handleRequest(
         }
       }
     } else {
-      response = await newResponse(response, { "x-function-cache-hit": "true" });
+      response = await newResponse(response, {
+        "x-function-cache-hit": "true",
+      });
     }
 
     // return not found page if no handler is found.
@@ -184,7 +189,9 @@ export function serveStatic(
       }
 
       const cType = contentType(String(lookup(filePath)));
-      if (cType) response = await newResponse(response, { "content-type": cType });
+      if (cType) {
+        response = await newResponse(response, { "content-type": cType });
+      }
 
       if (typeof intervene === "function") {
         response = await intervene(request, response);
@@ -201,7 +208,9 @@ export function serveStatic(
         response = (await globalCache.match(request)) as Response;
       }
     } else {
-      response = await newResponse(response, { "x-function-cache-hit": "true" });
+      response = await newResponse(response, {
+        "x-function-cache-hit": "true",
+      });
     }
 
     return response;

--- a/mod.ts
+++ b/mod.ts
@@ -58,7 +58,7 @@ export function serve(userRoutes: Routes): void {
 }
 
 async function newResponse(res: Response, headers: Record<string, string>): Promise<Response> {
-    return new Response(await res.blob(), {
+    return new Response(res.body, {
         headers: {
             ...Object.fromEntries(res.headers.entries()),
             ...headers,


### PR DESCRIPTION
closes #14
this PR adds a helper function to create a new Response with additional headers instead of trying to set headers on the original Response