### PR TITLE
fix: change newResponse return type

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -60,7 +60,7 @@ export function serve(userRoutes: Routes): void {
 function newResponse(
   res: Response,
   headers: Record<string, string>,
-): Promise<Response> {
+): Response {
   return new Response(res.body, {
     headers: {
       ...Object.fromEntries(res.headers.entries()),


### PR DESCRIPTION
Change newResponse return type from Promise<Response> to just Response

In 2e93474, unneeded async/await keywords get removed, but the function's return type is still a Promise