### PR TITLE
fix: handle all subtypes of HeadersInit

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -237,17 +237,20 @@ export function serveStatic(
  *```
  * */
 export function json(
-  // deno-lint-ignore no-explicit-any
-  jsobj: any,
+  jsobj: Parameters<typeof JSON.stringify>[0],
   init?: ResponseInit,
 ): Response {
+  const headers = (init?.headers instanceof Headers)
+    ? init.headers
+    : new Headers(init?.headers);
+
+  if (!headers.has('Content-Type')) {
+    headers.set('Content-Type', 'application/json; charset=utf-8');
+  }
   return new Response(JSON.stringify(jsobj) + "\n", {
     statusText: init?.statusText ?? STATUS_TEXT.get(init?.status ?? Status.OK),
     status: init?.status ?? Status.OK,
-    headers: {
-      "Content-Type": "application/json; charset=utf-8",
-      ...init?.headers,
-    },
+    headers,
   });
 }
 
@@ -268,13 +271,18 @@ export function json(
  * Make sure your file extension is either `.tsx` or `.jsx` and you've `h` imported
  * when using this function. */
 export function jsx(jsx: VNode, init?: ResponseInit): Response {
+  const headers = (init?.headers instanceof Headers)
+    ? init.headers
+    : new Headers(init?.headers);
+
+  if (!headers.has('Content-Type')) {
+    headers.set('Content-Type', 'text/html; charset=utf-8');
+  }
+
   return new Response(render(jsx), {
     statusText: init?.statusText ?? STATUS_TEXT.get(init?.status ?? Status.OK),
     status: init?.status ?? Status.OK,
-    headers: {
-      "Content-Type": "text/html; charset=utf-8",
-      ...init?.headers,
-    },
+    headers,
   });
 }
 

--- a/mod.ts
+++ b/mod.ts
@@ -6,7 +6,7 @@ import {
 import {
   Status,
   STATUS_TEXT,
-} from "https://deno.land/std@0.85.0/http/http_status.ts";
+} from "https://deno.land/std@0.100.0/http/http_status.ts";
 import { inMemoryCache } from "https://deno.land/x/httpcache@0.1.2/in_memory.ts";
 import { render } from "https://x.lcas.dev/preact@10.5.12/ssr.js";
 import {

--- a/mod.ts
+++ b/mod.ts
@@ -240,12 +240,12 @@ export function json(
   jsobj: Parameters<typeof JSON.stringify>[0],
   init?: ResponseInit,
 ): Response {
-  const headers = (init?.headers instanceof Headers)
+  const headers = init?.headers instanceof Headers
     ? init.headers
     : new Headers(init?.headers);
 
-  if (!headers.has('Content-Type')) {
-    headers.set('Content-Type', 'application/json; charset=utf-8');
+  if (!headers.has("Content-Type")) {
+    headers.set("Content-Type", "application/json; charset=utf-8");
   }
   return new Response(JSON.stringify(jsobj) + "\n", {
     statusText: init?.statusText ?? STATUS_TEXT.get(init?.status ?? Status.OK),
@@ -271,12 +271,12 @@ export function json(
  * Make sure your file extension is either `.tsx` or `.jsx` and you've `h` imported
  * when using this function. */
 export function jsx(jsx: VNode, init?: ResponseInit): Response {
-  const headers = (init?.headers instanceof Headers)
+  const headers = init?.headers instanceof Headers
     ? init.headers
     : new Headers(init?.headers);
 
-  if (!headers.has('Content-Type')) {
-    headers.set('Content-Type', 'text/html; charset=utf-8');
+  if (!headers.has("Content-Type")) {
+    headers.set("Content-Type", "text/html; charset=utf-8");
   }
 
   return new Response(render(jsx), {

--- a/test.ts
+++ b/test.ts
@@ -246,8 +246,8 @@ for (const { entries, headers, description } of headersInitCases) {
   });
 
   Deno.test(`HeadersInit: jsx() ${description}`, () => {
-    const vnode: VNode = {type: 'div', props: {children: null}, key: 'div'};
-    const response = jsx(vnode, {headers});
+    const vnode: VNode = { type: "div", props: { children: null }, key: "div" };
+    const response = jsx(vnode, { headers });
     for (const [key, value] of entries) {
       assertEquals(response.headers.get(key), value);
     }

--- a/test.ts
+++ b/test.ts
@@ -1,6 +1,6 @@
 import { assertEquals } from "https://deno.land/std@0.85.0/testing/asserts.ts";
 import { Status } from "https://deno.land/std@0.85.0/http/http_status.ts";
-import { json, validateRequest } from "./mod.ts";
+import { json, jsx, validateRequest } from "./mod.ts";
 import {
   createWorker,
   handlers,
@@ -190,3 +190,66 @@ Deno.test("validateRequest() populates body as per schema", async () => {
   assertEquals(error, undefined);
   assertEquals(body, { name: "Satya", age: 98 });
 });
+
+const headersInitCases: {
+  description: string;
+  headers: HeadersInit;
+  entries: [string, string][];
+}[] = [
+  {
+    description: "merges Headers",
+    headers: new Headers({
+      "content-type": "type/subtype",
+      "custom-header-1": "1",
+      "custom-header-2": "2",
+    }),
+    entries: [
+      ["content-type", "type/subtype"],
+      ["custom-header-1", "1"],
+      ["custom-header-2", "2"],
+    ],
+  },
+  {
+    description: "merges [string, string][]",
+    headers: [
+      ["content-type", "type/subtype"],
+      ["custom-header-1", "1"],
+      ["custom-header-2", "2"],
+    ],
+    entries: [
+      ["content-type", "type/subtype"],
+      ["custom-header-1", "1"],
+      ["custom-header-2", "2"],
+    ],
+  },
+  {
+    description: "merges Record<string, string>",
+    headers: {
+      "content-type": "type/subtype",
+      "custom-header-1": "1",
+      "custom-header-2": "2",
+    },
+    entries: [
+      ["content-type", "type/subtype"],
+      ["custom-header-1", "1"],
+      ["custom-header-2", "2"],
+    ],
+  },
+];
+
+for (const { entries, headers, description } of headersInitCases) {
+  Deno.test(`HeadersInit: json() ${description}`, () => {
+    const response = json(null, { headers });
+    for (const [key, value] of entries) {
+      assertEquals(response.headers.get(key), value);
+    }
+  });
+
+  Deno.test(`HeadersInit: jsx() ${description}`, () => {
+    const vnode = {type: 'div', props: {children: null}, key: 'div'};
+    const response = jsx(vnode, {headers});
+    for (const [key, value] of entries) {
+      assertEquals(response.headers.get(key), value);
+    }
+  });
+}

--- a/test.ts
+++ b/test.ts
@@ -1,6 +1,6 @@
 import { assertEquals } from "https://deno.land/std@0.100.0/testing/asserts.ts";
 import { Status } from "https://deno.land/std@0.100.0/http/http_status.ts";
-import { json, jsx, validateRequest } from "./mod.ts";
+import { json, jsx, validateRequest, VNode } from "./mod.ts";
 import {
   createWorker,
   handlers,
@@ -246,7 +246,7 @@ for (const { entries, headers, description } of headersInitCases) {
   });
 
   Deno.test(`HeadersInit: jsx() ${description}`, () => {
-    const vnode = {type: 'div', props: {children: null}, key: 'div'};
+    const vnode: VNode = {type: 'div', props: {children: null}, key: 'div'};
     const response = jsx(vnode, {headers});
     for (const [key, value] of entries) {
       assertEquals(response.headers.get(key), value);

--- a/test.ts
+++ b/test.ts
@@ -1,5 +1,5 @@
-import { assertEquals } from "https://deno.land/std@0.85.0/testing/asserts.ts";
-import { Status } from "https://deno.land/std@0.85.0/http/http_status.ts";
+import { assertEquals } from "https://deno.land/std@0.100.0/testing/asserts.ts";
+import { Status } from "https://deno.land/std@0.100.0/http/http_status.ts";
 import { json, jsx, validateRequest } from "./mod.ts";
 import {
   createWorker,


### PR DESCRIPTION
resolves #25

Hi @satyarohith. PTAL. A new test is probably needed, but I'm not sure how you are testing this module, so I'm not sure how to contribute in that area. (`deno test --unstable --prompt` throws all sorts of compiler type errors for me.)