### PR TITLE
Fix removing csp from files served from github

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -196,7 +196,7 @@ export function serveStatic(
     if (typeof response === "undefined") {
       response = await fetch(new Request(fileUrl, request));
       // Clone for us to be able to modify the response.
-      response = new Response(response.body, response);
+      response = newResponse(response, {});
 
       const contentType = getContentType(String(lookup(filePath)));
       if (contentType) {


### PR DESCRIPTION
Github csp header is not removed when file are served using the serveStatic function. this has been described in https://github.com/satyarohith/sift/issues/29#issuecomment-886202911

use newResponse in serveStatic
