### PR TITLE
BREAKING: use URLPattern

### DIFF
--- a/examples/03_route_params.ts
+++ b/examples/03_route_params.ts
@@ -3,7 +3,7 @@ import { serve } from "../mod.ts";
 serve({
   "/": (_request) => new Response("Hello World!"),
   "/blog/:slug": (_request, params) => {
-    return new Response(`You visited /${params.slug}`);
+    return new Response(`You visited /${params?.slug}`);
   },
   404: (_request) => new Response("Custom 404"),
 });

--- a/examples/04_serve_static_assets.ts
+++ b/examples/04_serve_static_assets.ts
@@ -3,7 +3,7 @@ import { serve, serveStatic } from "../mod.ts";
 serve({
   "/": (_request) => new Response("Hello World!"),
   "/blog/:slug": (_request, params) => {
-    return new Response(`You visited /${params.slug}`);
+    return new Response(`You visited /${params?.slug}`);
   },
   // The path should end with `filename+` for serveStatic to
   // construct correct URL to the requested resource.


### PR DESCRIPTION
I'm planning to pass the URLPatterResult to the request handler instead of just the pathname params in the future.

Closes #40 