### PR TITLE
Bump version of `media_types`

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -13,7 +13,7 @@ import { render } from "https://x.lcas.dev/preact@10.5.12/ssr.js";
 import {
   contentType as getContentType,
   lookup,
-} from "https://deno.land/x/media_types@v2.10.2/mod.ts";
+} from "https://deno.land/x/media_types@v2.11.1/mod.ts";
 import type { VNode } from "https://x.lcas.dev/preact@10.5.12/mod.d.ts";
 import { listenAndServe } from "https://deno.land/std@0.111.0/http/server.ts";
 


### PR DESCRIPTION
Fixes #52

Looks like the repository URL of `media_types` switched from `usesift/media_types` to `oakserver/media_types`.

This pull request bumps the version of `media_types` from `2.10.2` to `2.11.1`. Read #52 for more info.

Thanks.