### PR TITLE
fix(serveStatic): use 404 handler when `NotFound` (#54)

### DIFF
--- a/examples/04_serve_static_assets.ts
+++ b/examples/04_serve_static_assets.ts
@@ -14,5 +14,5 @@ serve({
   "/static/:filename+": serveStatic("../", {
     baseUrl: import.meta.url,
   }),
-  404: (_request) => new Response("Custom 404"),
+  404: (_request) => new Response("Custom 404", { status: 404 }),
 });

--- a/mod.ts
+++ b/mod.ts
@@ -78,6 +78,10 @@ async function handleRequest(
           try {
             response = await routes[route](request, params);
           } catch (error) {
+            if (error.name == "NotFound") {
+              break;
+            }
+
             console.error("Error serving request:", error);
             response = json({ error: error.message }, { status: 500 });
           }

--- a/test.ts
+++ b/test.ts
@@ -86,6 +86,18 @@ Deno.test({
       "text/markdown; charset=utf-8",
     );
 
+    // Test /static/missing which should serve a 404.
+    const expectedMissing = "Custom 404";
+    const [response3] = await script.fetch("/static/missing");
+    const text3 = await response3.text();
+    assertEquals(text3, expectedMissing);
+    assertEquals(response3.headers.get("x-function-cache-hit"), null);
+    assertEquals(
+      response3.headers.get("content-type"),
+      "text/plain;charset=UTF-8",
+    );
+    assertEquals(response3.status, 404);
+
     script.close();
   },
 });


### PR DESCRIPTION
fix #54 