### PR TITLE
docs: fix arguments for route Handler

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -30,7 +30,7 @@ import { serve } from "https://deno.land/x/sift@0.5.0/mod.ts";
 
 serve({
   "/": () => new Response("hello world"),
-  "/blog/:slug": (request, params) => {
+  "/blog/:slug": (request, connInfo, params) => {
     const post = `Hello, you visited ${params.slug}!`;
     return new Response(post);
   },


### PR DESCRIPTION
`params` is the third argument instead of second.