### PR TITLE
fix: argument of type VNode (fix #76)

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -22,8 +22,8 @@ import {
   lookup,
 } from "https://deno.land/x/media_types@v2.11.1/mod.ts";
 import { renderToString } from "https://esm.sh/preact-render-to-string@5.2.4?target=deno";
-import { type VNode } from "https://esm.sh/preact@10.10.6?target=deno";
-export * from "https://esm.sh/preact@10.10.6?target=deno";
+import { type VNode } from "https://esm.sh/preact@10.11.3?target=deno";
+export * from "https://esm.sh/preact@10.11.3?target=deno";
 
 export {
   Status,


### PR DESCRIPTION
Fix error https://github.com/satyarohith/sift/issues/76.

```
% deno test                                   
running 17 tests from ./test.ts
01_hello_world.ts ... ignored (0ms)
01_hello_world.tsx ... ignored (0ms)
02_custom_404.ts ... ignored (0ms)
03_route_params ... ignored (0ms)
04_serve_static_assets ... ignored (0ms)
json() response has correct content-type ... ok (6ms)
validateRequest() validates methods ... ok (4ms)
validateRequest() validates headers ... ok (4ms)
validateRequest() validates query strings ... ok (3ms)
validateRequest() validates body of POST request ... ok (4ms)
validateRequest() populates body as per schema ... ok (3ms)
HeadersInit: json() merges Headers ... ok (4ms)
HeadersInit: jsx() merges Headers ... ok (4ms)
HeadersInit: json() merges [string, string][] ... ok (4ms)
HeadersInit: jsx() merges [string, string][] ... ok (4ms)
HeadersInit: json() merges Record<string, string> ... ok (3ms)
HeadersInit: jsx() merges Record<string, string> ... ok (3ms)
```